### PR TITLE
fix: PSE-696 / GH Issue #38 an unknown value was passed

### DIFF
--- a/shared/payloads/product/VariantPayload.ts
+++ b/shared/payloads/product/VariantPayload.ts
@@ -1,4 +1,5 @@
 import SubscriptionConfigPayload from "../subscription/SubscriptionConfigPayload";
+import { ValidateIf } from "class-validator";
 
 interface VariantOptionPayload {
   id: number;
@@ -11,8 +12,20 @@ export default class VariantPayload {
   product_id: number;
   sku: string;
   sku_id: number;
-  price: number;
+  @ValidateIf((_object, value) => value !== null)
+  price: number | null;
   calculated_price: number;
+  @ValidateIf((_object, value) => value !== null)
+  sale_price: number | null;
+  @ValidateIf((_object, value) => value !== null)
+  retail_price: number | null;
+  @ValidateIf((_object, value) => value !== null)
+  map_price: number | null;
+  width: number;
+  calculated_weight: number;
+  weight: number;
+  height: number;
+  depth: number;
   image_url: string;
   cost_price: number;
   inventory_level: number;
@@ -20,8 +33,11 @@ export default class VariantPayload {
   bin_picking_number: string;
   option_values: VariantOptionPayload[];
   sub_config?: SubscriptionConfigPayload;
-  height: number;
-  depth: number;
-  weight: number;
-  width: number;
+  @ValidateIf((_object, value) => value !== null)
+  fixed_cost_shipping_price: number | null;
+  purchasing_disabled: boolean;
+  purchasing_disabled_message: string;
+  upc: string;
+  mpn: string;
+  gtin: string;
 }


### PR DESCRIPTION
**What***
-Don't validate certain values on VariantPayload if null, these are expected to be null at times

**Why***
forbidUnknownValues is true by default after the last upgrade of 'class-validator'

https://bigcommercecloud.atlassian.net/browse/PSE-696
https://github.com/bigcommerce/subscription-foundation/issues/38 

**Testing/Proof***
<img width="1591" alt="Screenshot 2023-06-22 at 9 00 06 PM" src="https://github.com/bigcommerce/subscription-foundation/assets/5630999/28c54323-29af-4299-b80b-fd9ba9b5f256">

