### PR TITLE
fix PSE-698 / GH #22 storefrontToken too long for type

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ model Store {
   hash                            String          @unique
   url                             String?
   accessToken                     String
-  storefrontToken                 String?
+  storefrontToken                 String?         @db.Text
   customerAttributeFieldId        Int?
   subscriptionsAttributeFieldId   Int?
   scriptId                        String?


### PR DESCRIPTION
**What**
Explicitly declare the type for storefrontToken 

**Why**
In some databases this string is too long for the default type

#22 - https://github.com/bigcommerce/subscription-foundation/issues/22

https://bigcommercecloud.atlassian.net/browse/PSE-698 

**Testing / Proof**

<img width="777" alt="Screenshot 2023-06-27 at 1 55 17 PM" src="https://github.com/bigcommerce/subscription-foundation/assets/5630999/3fc501f1-fc25-476e-bbe4-a78fed71f7dd">
