### PR TITLE
chore: PSE-699 Add Github issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Let us know what's not working
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen. Include a code sample or test case demonstrating the behavior that is not occurring / working as expected, as possible
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information, if applicable):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information, if applicable):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature---improvement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature---improvement-request.md
@@ -1,0 +1,21 @@
+---
+name: Feature / Improvement request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is and what the value of adding the new feature or improvement is. Ex. I'm always frustrated when [...]
+Ex. It would reduce time for developers if [...]
+
+**Describe the solution, feature, or improvement you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature or improvement request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Ask a question about this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Concise question or problem statement**
+A clear and concise question or problem statement, followed by clear question
+
+**Description of situation**
+Provide a more detailed description of the question, including what you are trying to achieve and what you are struggling to do or understand. 
+
+**Steps you've taken**
+If you are unable to resolve or figure something out, please tell us what you have tried to do.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What?
+
+Describe what changes you are making. e.g. `Adds X prop in the Box component.`
+
+## Why?
+
+Please provide the reason(s) why you are making this change? Please no one-liners like, `It was missing.`; expand upon the reason like, `Adds X prop because it was missing in the Box component. Documentation notes this prop exists, but it actually wasn't implemented.`
+
+## Screenshots/Screen Recordings
+
+This is a component library so we love visually looking at changes! If this applies to your pull request, show us your hard work in action.
+
+## Testing/Proof
+
+Explain how you tested your new feature or bugfix. Please refrain from one-liners like, `Added tests.`; expand upon how you tested your changes like, `Added local tests to the new component and ensured test coverage was met. Manually tested on Safari@x.x.x.`.


### PR DESCRIPTION
**What**
Create Github templates for PRs and Issues

**Why**
Provide standards and expectation for better support.

**Example**
Click "New Issue" to see the result - https://github.com/bigcommerce/big-design/issues